### PR TITLE
Creating database in a separate PS process

### DIFF
--- a/MonitoringDemo.Sql/Run.ps1
+++ b/MonitoringDemo.Sql/Run.ps1
@@ -98,8 +98,8 @@ try
                         Write-Host "Configuring LocalDB instance $instanceName"
                         $serverName = Add-LocalDbInstance -instanceName $instanceName
 
-                        Write-Host "Creating $databaseName database"
-                        New-Database -server ("(localdb)\" + $instanceName) -databaseName $databaseName
+                        $args = [string]::Format("-Command ""{0}\support\AddDatabaseInLocalDB.ps1"" {1} {2}", $PSScriptRoot, $instanceName, $databaseName)                        
+                        Start-Process PowerShell.exe -ArgumentList $args -WorkingDirectory $PSScriptRoot -Wait 
                         
                         $connectionString = New-ConnectionString -server $serverName -databaseName $databaseName
 

--- a/MonitoringDemo.Sql/support/AddDatabaseInLocalDB.ps1
+++ b/MonitoringDemo.Sql/support/AddDatabaseInLocalDB.ps1
@@ -1,0 +1,41 @@
+try {
+
+    [Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo")
+
+    Function New-Database
+    {
+        param(
+            [Parameter(Mandatory=$true)]
+            [ValidateNotNullOrEmpty()]
+            [string] $server,
+
+            [Parameter(Mandatory=$true)]
+            [ValidateNotNullOrEmpty()]
+            [string] $databaseName
+        )
+
+        $srv = New-Object Microsoft.SqlServer.Management.Smo.Server($server)
+
+        # Check can connect
+        $srv.ConnectionContext.Connect()
+
+        if ($srv.Databases[$databaseName] -ne $Null)
+        {
+            Write-Host "Dropping" + $databaseName
+            $srv.KillAllProcesses($databaseName)
+            $srv.KillDatabase($databaseName)
+        }
+
+        $db = New-Object Microsoft.SqlServer.Management.Smo.Database($srv, $databaseName)
+        
+        # TODO: Do we need to explicitly set credentials and create the schema? 
+        $db.Create()
+    }
+
+
+    Write-Host "Creating $databaseName database"
+    New-Database -server ("(localdb)\" + $args[0]) -databaseName $args[1]    
+}
+catch {
+    Read-Host
+}

--- a/MonitoringDemo.Sql/support/InstallLocalDB.ps1
+++ b/MonitoringDemo.Sql/support/InstallLocalDB.ps1
@@ -1,3 +1,28 @@
+Function Install-Msi {
+    param (
+        [System.IO.FileInfo]$file
+    )
+    $DataStamp = get-date -Format yyyyMMddTHHmmss
+    $logFile = '{0}-{1}.log' -f $file.fullname,$DataStamp
+    $MSIArguments = @(
+        "/i"
+        ('"{0}"' -f $file.fullname)
+        "/qn"
+        "/norestart"
+        "/L*v"
+        $logFile
+        "IACCEPTSQLLOCALDBLICENSETERMS=YES"
+    )
+    
+    $process = Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -NoNewWindow -PassThru
+    
+    if($process.ExitCode -ne 0){
+        Write-Error -Message "Failed installing ($file.Path)"
+        Read-Host
+    }
+    
+}
+
 try
 {
     Set-Location (Split-Path $script:MyInvocation.MyCommand.Path)

--- a/MonitoringDemo.Sql/support/Utils.psm1
+++ b/MonitoringDemo.Sql/support/Utils.psm1
@@ -1,36 +1,4 @@
-﻿[Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo")
-
-Function New-Database
-{
-    param(
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
-        [string] $server,
-
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
-        [string] $databaseName
-    )
-
-    $srv = New-Object Microsoft.SqlServer.Management.Smo.Server($server)
-
-    # Check can connect
-    $srv.ConnectionContext.Connect()
-
-    if ($srv.Databases[$databaseName] -ne $Null)
-    {
-        Write-Host "Dropping" + $databaseName
-        $srv.KillAllProcesses($databaseName)
-        $srv.KillDatabase($databaseName)
-    }
-
-    $db = New-Object Microsoft.SqlServer.Management.Smo.Database($srv, $databaseName)
-    
-    # TODO: Do we need to explicitly set credentials and create the schema? 
-    $db.Create()
-}
-
-Function New-ConnectionString {
+﻿Function New-ConnectionString {
     param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -59,44 +27,6 @@ Function New-ConnectionString {
     {
         return "server=$($server);Database=$($databaseName);Uid=$($uid);Pwd=$($pwd)"
     }
-}
-
-Function Install-Msi {
-    param (
-        [System.IO.FileInfo]$file
-    )
-    $DataStamp = get-date -Format yyyyMMddTHHmmss
-    $logFile = '{0}-{1}.log' -f $file.fullname,$DataStamp
-    $MSIArguments = @(
-        "/i"
-        ('"{0}"' -f $file.fullname)
-        "/qn"
-        "/norestart"
-        "/L*v"
-        $logFile
-        "IACCEPTSQLLOCALDBLICENSETERMS=YES"
-    )
-    
-    $process = Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -NoNewWindow -PassThru
-    
-    if($process.ExitCode -ne 0){
-        Write-Error -Message "Failed installing ($file.Path)"
-        Read-Host
-    }
-    
-}
-
-Function Add-LocalDbInstance {
-    param (
-        [string]$instanceName
-    )
-    
-    sqllocaldb create $instanceName | Out-Null
-    sqllocaldb share $instanceName $instanceName | Out-Null
-    sqllocaldb start $instanceName | Out-Null
-    $info = sqllocaldb info $instanceName
-
-    return $info.Split(" ") | where{$_ -like "np:\\.\pipe*"}
 }
 
 Function Update-ConnectionStrings {
@@ -156,4 +86,17 @@ Function Test-SQLConnection
         
         exit
     }
+}
+
+Function Add-LocalDbInstance {
+    param (
+        [string]$instanceName
+    )
+    
+    sqllocaldb create $instanceName | Out-Null
+    sqllocaldb share $instanceName $instanceName | Out-Null
+    sqllocaldb start $instanceName | Out-Null
+    $info = sqllocaldb info $instanceName
+
+    return $info.Split(" ") | where{$_ -like "np:\\.\pipe*"}
 }


### PR DESCRIPTION
Fixes #7 

## Overview
This is a change which runs script creating database in a localdb instance in separate PS process. This makes sure that even if SMO was installed in the previous step needed assemblies are available for loading