### PR TITLE
Updated packages to latest version.

### DIFF
--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -7,8 +7,8 @@
     <OutputPath>..\binaries\Billing\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.2" />
+    <PackageReference Include="NServiceBus" Version="7.2.4" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/src/ClientUI/ClientUI.csproj
+++ b/src/ClientUI/ClientUI.csproj
@@ -7,8 +7,8 @@
     <OutputPath>..\binaries\ClientUI\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.2" />
+    <PackageReference Include="NServiceBus" Version="7.2.4" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/src/Messages/Messages.csproj
+++ b/src/Messages/Messages.csproj
@@ -8,6 +8,6 @@
     <AssemblyOriginatorKeyFile>messages.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
+    <PackageReference Include="NServiceBus" Version="7.2.4" />
   </ItemGroup>
 </Project>

--- a/src/Sales/Sales.csproj
+++ b/src/Sales/Sales.csproj
@@ -7,8 +7,8 @@
     <OutputPath>..\binaries\Sales\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.2" />
+    <PackageReference Include="NServiceBus" Version="7.2.4" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Serilog" Version="6.1.3" />
+    <PackageReference Include="NServiceBus.Serilog" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Shipping/Shipping.csproj
+++ b/src/Shipping/Shipping.csproj
@@ -7,8 +7,8 @@
     <OutputPath>..\binaries\Shipping\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.1.6" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.2" />
+    <PackageReference Include="NServiceBus" Version="7.2.4" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Updated to latest version, not sure why dependabot isn't working here but on the other hand. As this is a demo, why couldn't just all particular dependencies be a wildcard?