### PR TITLE
Enable heartbeats in monitoring demo

### DIFF
--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/src/Billing/Program.cs
+++ b/src/Billing/Program.cs
@@ -25,6 +25,7 @@
                 .Delayed(delayed => delayed.NumberOfRetries(0));
 
             endpointConfiguration.AuditProcessedMessagesTo("audit");
+            endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
 
             endpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomIdentifier(new Guid("1C62248E-2681-45A4-B44D-5CF93584BAD6"))

--- a/src/ClientUI/ClientUI.csproj
+++ b/src/ClientUI/ClientUI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/src/ClientUI/Program.cs
+++ b/src/ClientUI/Program.cs
@@ -23,6 +23,7 @@
             var transport = endpointConfiguration.UseTransport<LearningTransport>();
 
             endpointConfiguration.AuditProcessedMessagesTo("audit");
+            endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
 
             endpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomIdentifier(new Guid("EA3E7D1B-8171-4098-B160-1FEA975CCB2C"))

--- a/src/Sales/Program.cs
+++ b/src/Sales/Program.cs
@@ -40,6 +40,7 @@
             endpointConfiguration.UseTransport<LearningTransport>();
 
             endpointConfiguration.AuditProcessedMessagesTo("audit");
+            endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
 
             endpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomDisplayName(instanceName)

--- a/src/Sales/Sales.csproj
+++ b/src/Sales/Sales.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/src/Shipping/Program.cs
+++ b/src/Shipping/Program.cs
@@ -22,6 +22,7 @@
             endpointConfiguration.UseTransport<LearningTransport>();
 
             endpointConfiguration.AuditProcessedMessagesTo("audit");
+            endpointConfiguration.SendHeartbeatTo("Particular.ServiceControl");
 
             endpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomIdentifier(new Guid("BB8A8BAF-4187-455E-AAD2-211CD43267CB"))

--- a/src/Shipping/Shipping.csproj
+++ b/src/Shipping/Shipping.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.3.0" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="3.0.1" />
     <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="3.0.4" />
     <ProjectReference Include="..\Messages\Messages.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />


### PR DESCRIPTION
Heartbeats is part of monitoring. There doesn't seem to be any reason that the monitoring demo should showcase broken heartbeats.