### PR TITLE
Switch to NServiceBus.Extensions.Logging

### DIFF
--- a/src/Shared/LoggingUtils.cs
+++ b/src/Shared/LoggingUtils.cs
@@ -1,11 +1,12 @@
 ﻿namespace Shared
 {
+    using NServiceBus.Extensions.Logging;
+    using Serilog.Extensions.Logging;
     using System;
     using System.IO;
     using System.Linq;
     using System.Reflection;
     using NServiceBus.Logging;
-    using NServiceBus.Serilog;
     using Serilog;
 
     public static class LoggingUtils
@@ -24,10 +25,10 @@
                 .WriteTo.File(logPath)
                 .CreateLogger();
 
-            LogManager.Use<SerilogFactory>();
+            LogManager.UseFactory(new ExtensionsLoggerFactory(new SerilogLoggerFactory()));
         }
 
-        private static string GetLogLocation()
+        static string GetLogLocation()
         {
             var assemblyPath = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
             var assemblyFolder = Path.GetDirectoryName(assemblyPath);
@@ -42,7 +43,7 @@
             return (logLocation ?? workingDir).FullName;
         }
 
-        private static DirectoryInfo FindLogFolder(DirectoryInfo currentDir)
+        static DirectoryInfo FindLogFolder(DirectoryInfo currentDir)
         {
             if (currentDir == null)
             {

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -5,9 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Serilog" Version="7.16.0" />
-    <PackageReference Include="Particular.CodeRules" Version="0.8.0" PrivateAssets="All" />
+    <PackageReference Include="NServiceBus.Extensions.Logging" Version="1.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Particular.CodeRules" Version="0.8.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replaces https://github.com/Particular/MonitoringDemo/pull/113 because NServiceBus.Serilog doesn't support .NET Framework anymore.