### PR TITLE
Automate releases based on PlatformSample versions

### DIFF
--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -7,6 +7,8 @@ on:
 defaults:
   run:
     shell: pwsh
+env:
+  GH_TOKEN: ${{ github.token }}
 jobs:
   check:
     name: Check dependencies
@@ -14,6 +16,8 @@ jobs:
     steps:
       - name: Download deployed dependencies
         run: |
+          # Compare deployed dependencies to NuGet versions and invoke release if mismatch exists
+
           $url = "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json"
           echo "Getting currently-deployed dependencies from $url"
           $current = (Invoke-WebRequest $url).Content | ConvertFrom-Json

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - name: Download deployed dependencies
         run: |
-          echo "Getting currently-deployed dependencies file"
-          $current = (Invoke-WebRequest "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json").Content | ConvertFrom-Json
+          $url = "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json"
+          echo "Getting currently-deployed dependencies from $url"
+          $current = (Invoke-WebRequest $url).Content | ConvertFrom-Json
           echo $current | ConvertTo-Json
 
           echo "Getting most recent versions from NuGet"
@@ -46,6 +47,7 @@ jobs:
 
           if ($upToDate) {
             echo "Everything is up-to-date, nothing to do"
+            gh workflow run release.yml
           } else {
             echo "Updates are needed, should invoke release workflow"
           }

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Download deployed dependencies
         run: |
           echo "Getting currently-deployed dependencies file"
-          Invoke-WebRequest "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json" -OutFile https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json"
-          Get-Content ./dependencies.json
-          $current = Get-Content ./dependencies.json | ConvertFrom-Json
+          $current = (Invoke-WebRequest "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json").Content | ConvertFrom-Json
+          echo $current | ConvertTo-Json
 
           echo "Getting most recent versions from NuGet"
           $serviceControl = Find-Package Particular.PlatformSample.ServiceControl
@@ -32,15 +31,15 @@ jobs:
           echo $latest | ConvertTo-Json
 
           $upToDate = $true
-          if ($current.PlatformSample != $latest.PlatformSample) {
+          if ($current.PlatformSample -ne $latest.PlatformSample) {
             echo "PlatformSample version does not match"
             $upToDate = $false
           }
-          if ($current.ServiceControl != $latest.ServiceControl) {
+          if ($current.ServiceControl -ne $latest.ServiceControl) {
             echo "ServiceControl version does not match"
             $upToDate = $false
           }
-          if ($current.ServicePulse != $latest.ServicePulse) {
+          if ($current.ServicePulse -ne $latest.ServicePulse) {
             echo "ServicePulse version does not match"
             $upToDate = $false
           }

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -1,0 +1,52 @@
+name: Check Platform Sample Dependencies
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1-5' # Hourly, Monday-Friday
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  check:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download deployed dependencies
+        run: |
+          echo "Getting currently-deployed dependencies file"
+          Invoke-WebRequest "https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json" -OutFile https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json"
+          Get-Content ./dependencies.json
+          $current = Get-Content ./dependencies.json | ConvertFrom-Json
+
+          echo "Getting most recent versions from NuGet"
+          $serviceControl = Find-Package Particular.PlatformSample.ServiceControl
+          $servicePulse = Find-Package Particular.PlatformSample.ServicePulse
+          $platformSample = Find-Package Particular.PlatformSample
+
+          $latest = @{
+            PlatformSample = $platformSample.Version
+            ServiceControl = $serviceControl.Version
+            ServicePulse = $servicePulse.Version
+          }
+          echo $latest | ConvertTo-Json
+
+          $upToDate = $true
+          if ($current.PlatformSample != $latest.PlatformSample) {
+            echo "PlatformSample version does not match"
+            $upToDate = $false
+          }
+          if ($current.ServiceControl != $latest.ServiceControl) {
+            echo "ServiceControl version does not match"
+            $upToDate = $false
+          }
+          if ($current.ServicePulse != $latest.ServicePulse) {
+            echo "ServicePulse version does not match"
+            $upToDate = $false
+          }
+
+          if ($upToDate) {
+            echo "Everything is up-to-date, nothing to do"
+          } else {
+            echo "Updates are needed, should invoke release workflow"
+          }

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -54,7 +54,34 @@ jobs:
 
           if ($upToDate) {
             echo "Everything is up-to-date, nothing to do"
-            gh workflow run release.yml
           } else {
-            echo "Updates are needed, should invoke release workflow"
+            echo "Updates are needed, going to invoke release workflow"
+
+            # Notify Slack first
+            $headers = @{ 'Authorization' = "Bearer ${{ secrets.SLACK_TOKEN }}" }
+            $body = @{
+              channel = 'pulse-and-control'
+              text = "Attempting to auto-update MonitoringDemo due to changes detected in PlatformSample packages: https://github.com/Particular/MonitoringDemo/actions/runs/${{ github.run_id }}"
+              username = 'MonitoringDemo UpdateBot'
+              icon_emoji = 'rocket'
+              unfurl_links = false
+            } | ConvertTo-Json
+            $result = Invoke-RestMethod -Method POST -Uri https://slack.com/api/chat.postMessage -ContentType "application/json; charset=utf-8" -Headers $headers -Body $body
+
+            # Invoke workflow
+            gh workflow run release.yml
           }
+      - name: Notify Slack on failure
+        if: ${{ failure() }}
+        shell: pwsh
+        run: |
+          $headers = @{ 'Authorization' = "Bearer ${{ secrets.SLACK_TOKEN }}" }
+          $body = @{
+            channel = 'pulse-and-control'
+            text = "Failure in MonitoringDemo auto-update workflow: https://github.com/Particular/MonitoringDemo/actions/runs/${{ github.run_id }}"
+            username = 'MonitoringDemo UpdateBot'
+            icon_emoji = 'warning'
+            unfurl_links = false
+          } | ConvertTo-Json
+          $result = Invoke-RestMethod -Method POST -Uri https://slack.com/api/chat.postMessage -ContentType "application/json; charset=utf-8" -Headers $headers -Body $body
+          exit $(If ($result.ok) { 0 } Else { 1 })

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -14,6 +14,9 @@ jobs:
     name: Check dependencies
     runs-on: ubuntu-latest
     steps:
+      # Checkout required for GitHub CLI to work
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
       - name: Download deployed dependencies
         run: |
           # Compare deployed dependencies to NuGet versions and invoke release if mismatch exists

--- a/.github/workflows/platformsample-dependencies.yml
+++ b/.github/workflows/platformsample-dependencies.yml
@@ -1,6 +1,5 @@
 name: Check Platform Sample Dependencies
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 * * * 1-5' # Hourly, Monday-Friday
@@ -26,15 +25,18 @@ jobs:
           $current = (Invoke-WebRequest $url).Content | ConvertFrom-Json
           echo $current | ConvertTo-Json
 
-          echo "Getting most recent versions from NuGet"
-          $serviceControl = Find-Package Particular.PlatformSample.ServiceControl
-          $servicePulse = Find-Package Particular.PlatformSample.ServicePulse
-          $platformSample = Find-Package Particular.PlatformSample
+          echo "Getting most recent versions from NuGet API"
+          $nugetMeta = (Invoke-WebRequest "https://api.nuget.org/v3/index.json").Content | ConvertFrom-Json
+          $nugetBaseUrl = ($nugetMeta.resources | Where-Object -Property '@type' -eq 'RegistrationsBaseUrl/Versioned')[0].'@id'
+
+          $serviceControl = (Invoke-WebRequest "$($nugetBaseUrl)particular.platformsample.servicecontrol/index.json").Content | ConvertFrom-Json
+          $servicePulse = (Invoke-WebRequest "$($nugetBaseUrl)particular.platformsample.servicepulse/index.json").Content | ConvertFrom-Json
+          $platformSample = (Invoke-WebRequest "$($nugetBaseUrl)particular.platformsample/index.json").Content | ConvertFrom-Json
 
           $latest = @{
-            PlatformSample = $platformSample.Version
-            ServiceControl = $serviceControl.Version
-            ServicePulse = $servicePulse.Version
+            PlatformSample = ($platformSample.items | select -Last 1).upper
+            ServiceControl = ($serviceControl.items | select -Last 1).upper
+            ServicePulse = ($servicePulse.items | select -Last 1).upper
           }
           echo $latest | ConvertTo-Json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,27 @@ jobs:
           aws s3 cp ./Particular.MonitoringDemo.zip s3://particular.downloads/MonitoringDemo/Particular.MonitoringDemo.zip --content-type application/zip --acl public-read
 
           echo "Complete"
+      - name: Write dependency file
+        uses: ./.github/actions/write-dependencies
+      - name: Upload dependency file to AWS
+        shell: pwsh
+        run: |
+          $dotnetPackages = dotnet list src/Platform package --include-transitive --format json | ConvertFrom-Json
+          $firstProject = $dotnetPackages.projects[0]
+          $firstTfm = $firstProject.frameworks[0]
+          $allPackages = $firstTfm.topLevelPackages + $firstTfm.transitivePackages
+
+          $versions = @{
+            PlatformSample = ($allPackages | Where-Object -Property id -EQ 'Particular.PlatformSample').resolvedVersion
+            ServiceControl = ($allPackages | Where-Object -Property id -EQ 'Particular.PlatformSample.ServiceControl').resolvedVersion
+            ServicePulse = ($allPackages | Where-Object -Property id -EQ 'Particular.PlatformSample.ServicePulse').resolvedVersion
+          }
+
+          $json = $versions | ConvertTo-Json
+          echo "Writing dependencies file ./dependencies.json containing:"
+          echo $json
+          echo $json > dependencies.json
+
+          echo "Uploading to https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json"
+          aws s3 cp ./dependencies.json s3://particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json --content-type application/json --acl public-read
+          echo "Complete"


### PR DESCRIPTION
The deployed versions of the PlatformSample package, ServiceControl package, and ServicePulse package are now [represented in a deployed release artifact](https://s3.amazonaws.com/particular.downloads/MonitoringDemo/Particular.MonitoringDemo.dependencies.json) so that we know if the versions of ServiceControl and ServicePulse built into the MonitoringDemo are the latest versions.

This PR updates that release artifact on every release, and an hourly workflow will query NuGet to see what the latest versions are, and in the event that there is a newer version available, will trigger the release workflow to update them.

Also related to the following PRs to simplify the ServiceControl and ServicePulse release procedure:

* https://github.com/Particular/Particular.PlatformSample/pull/475
* https://github.com/Particular/Particular.PlatformSample/pull/472