### PR TITLE
Single-window mode for using at conference booth (draft)

### DIFF
--- a/src/Billing/Billing.csproj
+++ b/src/Billing/Billing.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.0.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.0.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
   </ItemGroup>
 
 </Project>

--- a/src/ClientUI/ClientUI.csproj
+++ b/src/ClientUI/ClientUI.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.0.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.0.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
   </ItemGroup>
 
 </Project>

--- a/src/MonitoringDemo/DemoLauncher.cs
+++ b/src/MonitoringDemo/DemoLauncher.cs
@@ -2,9 +2,12 @@
 
 sealed class DemoLauncher : IDisposable
 {
-    public DemoLauncher()
+    readonly bool remoteControlMode;
+
+    public DemoLauncher(bool remoteControlMode)
     {
-        demoJob = new Job("Particular.MonitoringDemo");
+        this.remoteControlMode = remoteControlMode;
+        demoJob = new Job("Particular.MonitoringDemo", remoteControlMode);
 
         File.WriteAllText(@".\Marker.sln", string.Empty);
     }
@@ -28,6 +31,14 @@ sealed class DemoLauncher : IDisposable
         DirectoryEx.ForceDeleteReadonly(".audit-db");
     }
 
+    public void Send(string value)
+    {
+        demoJob.Send(billingPath, 0, value);
+        demoJob.Send(shippingPath, 0, value);
+        demoJob.Send(clientPath, 0, value);
+        demoJob.Send(salesPath, 0, value);
+    }
+
     public void Platform()
     {
         if (disposed)
@@ -45,7 +56,7 @@ sealed class DemoLauncher : IDisposable
             return;
         }
 
-        demoJob.AddProcess(Path.Combine("Billing", "Billing.exe"));
+        demoJob.AddProcess(billingPath);
     }
 
     public void Shipping()
@@ -55,7 +66,7 @@ sealed class DemoLauncher : IDisposable
             return;
         }
 
-        demoJob.AddProcess(Path.Combine("Shipping", "Shipping.exe"));
+        demoJob.AddProcess(shippingPath);
     }
 
     public void ScaleOutSales()
@@ -65,7 +76,7 @@ sealed class DemoLauncher : IDisposable
             return;
         }
 
-        demoJob.AddProcess(Path.Combine("Sales", "Sales.exe"));
+        demoJob.AddProcess(salesPath);
     }
 
     public void ScaleInSales()
@@ -75,7 +86,7 @@ sealed class DemoLauncher : IDisposable
             return;
         }
 
-        demoJob.KillProcess(Path.Combine("Sales", "Sales.exe"));
+        demoJob.KillProcess(salesPath);
     }
 
     public void ClientUI()
@@ -85,9 +96,13 @@ sealed class DemoLauncher : IDisposable
             return;
         }
 
-        demoJob.AddProcess(Path.Combine("ClientUI", "ClientUI.exe"));
+        demoJob.AddProcess(clientPath);
     }
 
     readonly Job demoJob;
     private bool disposed;
+    private static readonly string billingPath = Path.Combine("Billing", "Billing.exe");
+    private static readonly string shippingPath = Path.Combine("Shipping", "Shipping.exe");
+    private static readonly string salesPath = Path.Combine("Sales", "Sales.exe");
+    private static readonly string clientPath = Path.Combine("ClientUI", "ClientUI.exe");
 }

--- a/src/MonitoringDemo/Program.cs
+++ b/src/MonitoringDemo/Program.cs
@@ -1,4 +1,5 @@
-﻿using MonitoringDemo;
+﻿using System.Diagnostics;
+using MonitoringDemo;
 
 CancellationTokenSource tokenSource = new();
 Console.Title = "MonitoringDemo";
@@ -11,9 +12,12 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     syncEvent.TrySetResult(true);
 };
 
+//Debugger.Launch();
+var remoteControlMode = args.Length > 0 && string.Equals(args[0], bool.TrueString, StringComparison.InvariantCultureIgnoreCase);
+
 try
 {
-    using var launcher = new DemoLauncher();
+    using var launcher = new DemoLauncher(remoteControlMode);
     Console.WriteLine("Starting the Particular Platform");
 
     launcher.Platform();
@@ -79,15 +83,17 @@ void ScaleSalesEndpointIfRequired(DemoLauncher launcher, TaskCompletionSource<bo
             while (!tokenSource.IsCancellationRequested)
             {
                 var input = Console.ReadKey(true);
-
-                switch (input.Key)
+                if (input.Key == ConsoleKey.LeftArrow)
                 {
-                    case ConsoleKey.DownArrow:
-                        launcher.ScaleInSales();
-                        break;
-                    case ConsoleKey.UpArrow:
-                        launcher.ScaleOutSales();
-                        break;
+                    launcher.ScaleInSales();
+                }
+                else if (input.Key == ConsoleKey.RightArrow)
+                {
+                    launcher.ScaleOutSales();
+                }
+                else
+                {
+                    launcher.Send(new string(input.KeyChar, 1));
                 }
             }
         }

--- a/src/Sales/Sales.csproj
+++ b/src/Sales/Sales.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.0.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.0.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
   </ItemGroup>
 
 </Project>

--- a/src/Shared/LoggingUtils.cs
+++ b/src/Shared/LoggingUtils.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Diagnostics;
 using System.Reflection;
 using NServiceBus.Extensions.Logging;
 using NServiceBus.Logging;
@@ -49,7 +50,7 @@ public static class LoggingUtils
             return null;
         }
 
-        var logsFolders = currentDir.GetDirectories("logs", SearchOption.TopDirectoryOnly);
+        var logsFolders = currentDir.GetDirectories(".logs", SearchOption.TopDirectoryOnly);
 
         return logsFolders.FirstOrDefault() ?? FindLogFolder(currentDir.Parent);
     }

--- a/src/Shared/OpenTelemetryUtils.cs
+++ b/src/Shared/OpenTelemetryUtils.cs
@@ -1,0 +1,31 @@
+﻿using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+
+namespace Shared;
+
+public static class OpenTelemetryUtils
+{
+    public static IDisposable ConfigureOpenTelemetry(this EndpointConfiguration endpointConfig, string name, string id, int port)
+    {
+        var attributes = new Dictionary<string, object>
+        {
+            ["service.name"] = name,
+            ["service.instance.id"] = id,
+        };
+
+        var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(attributes);
+
+        var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+            .SetResourceBuilder(resourceBuilder)
+            .AddMeter("NServiceBus.Core*");
+
+        meterProviderBuilder.AddPrometheusHttpListener(options => options.UriPrefixes = new[] { $"http://127.0.0.1:{port}" });
+
+        var meterProvider = meterProviderBuilder.Build();
+
+        endpointConfig.EnableOpenTelemetry();
+
+        return meterProvider;
+    }
+}

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="NServiceBus.Extensions.Logging" Version="3.*" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.*-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Shared/UserInterface.cs
+++ b/src/Shared/UserInterface.cs
@@ -1,0 +1,70 @@
+﻿namespace Shared;
+
+public class UserInterface
+{
+    public static void RunLoop(string title, Dictionary<char, (string, Action)> controls, Action<TextWriter> reportState, bool interactive)
+    {
+        if (interactive)
+        {
+            RunInteractiveLoop(title, controls, reportState);
+        }
+        else
+        {
+            RunNonInteractiveLoop(title, controls, reportState);
+        }
+    }
+
+    static void RunInteractiveLoop(string title, Dictionary<char, (string, Action)> controls, Action<TextWriter> reportState)
+    {
+        Console.Title = title;
+        Console.SetWindowSize(65, 15);
+
+        while (true)
+        {
+            Console.Clear();
+            foreach (var kvp in controls)
+            {
+                Console.WriteLine($"Press {char.ToUpperInvariant(kvp.Key)} to {kvp.Value.Item1}");
+            }
+            Console.WriteLine("Press ESC to quit");
+            Console.WriteLine();
+
+            reportState(Console.Out);
+
+            var input = Console.ReadKey(true);
+
+            if (controls.TryGetValue(char.ToLowerInvariant(input.KeyChar), out var action))
+            {
+                action.Item2();
+            }
+            else if (input.Key == ConsoleKey.Escape)
+            {
+                return;
+            }
+        }
+    }
+
+    static void RunNonInteractiveLoop(string title, Dictionary<char, (string, Action)> controls, Action<TextWriter> reportState)
+    {
+        Console.Title = title;
+
+        reportState(Console.Out);
+
+        while (true)
+        {
+            var input = Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return;
+            }
+
+            var key = input[0];
+
+            if (controls.TryGetValue(char.ToLowerInvariant(key), out var action))
+            {
+                action.Item2();
+                reportState(Console.Out);
+            }
+        }
+    }
+}

--- a/src/Shipping/Shipping.csproj
+++ b/src/Shipping/Shipping.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.0.0" />
-    <PackageReference Include="NServiceBus.Heartbeat" Version="5.0.0" />
-    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.0.0" />
+    <PackageReference Include="NServiceBus" Version="9.*" />
+    <PackageReference Include="NServiceBus.Heartbeat" Version="5.*" />
+    <PackageReference Include="NServiceBus.Metrics.ServiceControl" Version="5.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
For NDC London 2025. I just pushed whatever I had customized for Porto. When you pass `True` as the first param, it runs the child processes window-less and redirects input so that you can control all the processes from one console window.

